### PR TITLE
Adds the ability to pass a block to `run` that will be yielded for each line of output.

### DIFF
--- a/lib/phantomjs.rb
+++ b/lib/phantomjs.rb
@@ -13,7 +13,14 @@ module Phantomjs
   def run(script, *args)
     string_args = args.join(" ")
     @executable ||= get_executable
-    `#{@executable} #{script} #{string_args}`
+
+    if block_given?
+      IO.popen("#{@executable} #{script} #{string_args}").each_line do |line|
+        yield line
+      end
+    else
+      `#{@executable} #{script} #{string_args}`
+    end
   end
 
   private

--- a/spec/phantomjs_spec.rb
+++ b/spec/phantomjs_spec.rb
@@ -7,5 +7,14 @@ describe Phantomjs do
       result = Phantomjs.run(script, 'foo1', 'foo2')
       result.should eq("bar foo1 foo2\n")
     end
+    
+    it "accepts a block that will get called for each line of output" do
+      line = ''
+      script = File.expand_path('./spec/runner.js')
+      Phantomjs.run(script, 'foo1', 'foo2') do |l|
+        line << l
+      end
+      line.should eq("bar foo1 foo2\n")
+    end
   end
 end


### PR DESCRIPTION
We're using Phantomjs.rb in a test runner, and needed this functionality to output each line as the specs are being executed, instead of waiting until the end for the output.

Thanks for the project!
